### PR TITLE
Feat: Deactivate account

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ GET /: Root URL response.
 | `DELETE` | `/customers/<customer_id>` | Delete a customer with the given `id`. |
 | `GET` | `/customers` | List all customers. |
 | `PUT` | `/customers/<customer_id>` | Update an existing customer with the given `id`. |
+| `PUT` | `/customers/<customer_id>/deactivate` | Deactivate a customer with the given `id`. |
 
 ### Usage
 

--- a/service/models.py
+++ b/service/models.py
@@ -151,6 +151,11 @@ class Customer(db.Model):
             ) from error
         return self
 
+    def deactivate(self):
+        """Deactivates the customer account"""
+        self.active = False
+        self.update()
+
     ##################################################
     # CLASS METHODS
     ##################################################

--- a/service/routes.py
+++ b/service/routes.py
@@ -28,7 +28,7 @@ from service.common import status  # HTTP Status Codes
 
 
 def encrypt_password(password):
-    """ Hashing Passwords """
+    """Hashing Passwords"""
     return hashlib.sha256(password.encode("UTF-8")).hexdigest()
 
 
@@ -42,17 +42,22 @@ def index():
     #     "Reminder: return some useful information in json format about the service here",
     #     status.HTTP_200_OK,
     # )
-    return jsonify({
-        "1_Customers": "Welcome to the Customer Store Service API. This API allows you to manage the customers.",
-        "2_methods_available": {
-            "2.1 GET /customers/<customer_id>": "Retrieve a single customer by ID.",
-            "2.2 POST /customers": "Create a new customer.",
-            "2.3 DELETE /customers/<customer_id>": "Delete a customer by ID.",
-            "2.4 GET /customers": "Retrieve a list of all customers.",
-            "2.5 PUT /customers/<customer_id>": "Update an existing customer by ID."
-        },
-        "3_contact": "For more information, refer to the API documentation or contact support@example.com."
-    }), status.HTTP_200_OK
+    return (
+        jsonify(
+            {
+                "1_Customers": "Welcome to the Customer Store Service API. This API allows you to manage the customers.",
+                "2_methods_available": {
+                    "2.1 GET /customers/<customer_id>": "Retrieve a single customer by ID.",
+                    "2.2 POST /customers": "Create a new customer.",
+                    "2.3 DELETE /customers/<customer_id>": "Delete a customer by ID.",
+                    "2.4 GET /customers": "Retrieve a list of all customers.",
+                    "2.5 PUT /customers/<customer_id>": "Update an existing customer by ID.",
+                },
+                "3_contact": "For more information, refer to the API documentation or contact support@example.com.",
+            }
+        ),
+        status.HTTP_200_OK,
+    )
 
 
 ######################################################################
@@ -79,9 +84,7 @@ def get_customers(customer_id):
             f"Customer with id '{customer_id}' was not found.",
         )
 
-    app.logger.info(
-        "Returning customer: %s", customer.id
-    )
+    app.logger.info("Returning customer: %s", customer.id)
     return jsonify(customer.serialize()), status.HTTP_200_OK
 
 
@@ -173,6 +176,26 @@ def update_customers(customer_id):
 
     app.logger.info("Customer with ID: %d updated.", customer.id)
     return jsonify(customer.serialize()), status.HTTP_200_OK
+
+
+######################################################################
+# DEACTIVATE A CUSTOMER
+######################################################################
+@app.route("/customers/<int:customer_id>/deactivate", methods=["PUT"])
+def deactivate_customer(customer_id):
+    """
+    Deactivate a customer
+    This endpoint will deactivate a customer based on the id specified in the path
+    """
+    customer = Customer.find(customer_id)
+    if not customer:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Customer with id '{customer_id}' was not found.",
+        )
+
+    customer.deactivate()
+    return jsonify(""), status.HTTP_204_NO_CONTENT
 
 
 ######################################################################

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -320,6 +320,14 @@ class TestCustomer(TestCase):
             f"<Customer {test_customer.first_name, test_customer.last_name} id=[{test_customer.id}]>",
         )
 
+    def test_deactivate_a_customer(self):
+        """It should Deactivate a Customer"""
+        customer = CustomerFactory()
+        customer.active = True
+        self.assertTrue(customer.active)
+        customer.deactivate()
+        self.assertFalse(customer.active)
+
 
 ######################################################################
 #  Q U E R Y   T E S T   C A S E S

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -230,3 +230,21 @@ class TestCustomerService(TestCase):
         response = self.client.post("/customers", data="{}", content_type="text/plain")
         self.assertEqual(response.status_code, 415)
         self.assertIn("Unsupported media type", response.json["error"])
+
+    def test_deactivate_customer(self):
+        """It should Deactivate a Customer"""
+        test_customer_data = CustomerFactory().serialize()
+        test_customer_data["active"] = True
+        # Create customer via POST request
+        create_response = self.client.post(BASE_URL, json=test_customer_data)
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        created_customer = create_response.get_json()
+
+        # Deactivate the customer via PUT request
+        response = self.client.put(f"{BASE_URL}/{created_customer['id']}/deactivate")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Fetch the customer to verify it's deactivated
+        get_response = self.client.get(f"{BASE_URL}/{created_customer['id']}")
+        deactivated_customer = get_response.get_json()
+        self.assertFalse(deactivated_customer["active"])

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -248,3 +248,9 @@ class TestCustomerService(TestCase):
         get_response = self.client.get(f"{BASE_URL}/{created_customer['id']}")
         deactivated_customer = get_response.get_json()
         self.assertFalse(deactivated_customer["active"])
+
+    def test_deactivate_nonexistent_customer(self):
+        """It should return 404 for a nonexistent customer"""
+        nonexistent_customer_id = 99999  # Assuming this ID does not exist
+        response = self.client.put(f"{BASE_URL}/{nonexistent_customer_id}/deactivate")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Added endpoint, `/customers/<customer_id>/deactivate`, updates the customer's `active` status to `false`, effectively deactivating the account without deleting any customer data. 

**Key Changes:**
- Added a new route in `service/routes.py` for handling the deactivation request via a `PUT` method.
- Implemented the `deactivate` method in `service/models.py` to update the `active` status of a customer instance.
- Added tests in `tests/test_routes.py` to ensure the endpoint correctly deactivates a customer and returns the appropriate HTTP status code.
- Updated the README.md to include documentation for the new endpoint, ensuring clarity on its usage for future developers and users.

**Testing:**
- A customer is successfully deactivated with a `204 NO CONTENT` response.
- Attempting to deactivate a non-existent customer returns a `404 NOT FOUND` response.
- The `active` field of a deactivated customer is correctly updated in the database.
