### PR TITLE
codecov report generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Upload code coverage
         uses: codecov/codecov-action@v3.1.4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: 3800280b-3a92-4869-8e84-082f2b393ff0
           slug: CSCI-GA-2820-SP24-003/customers
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,7 @@ jobs:
       
       - name: Upload code coverage
         uses: codecov/codecov-action@v3.1.4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: CSCI-GA-2820-SP24-003/customers
   

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -416,7 +416,7 @@ class TestCustomerService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
     def test_activate_customer(self):
-        """It should Deactivate a Customer"""
+        """It should Activate a Customer"""
         test_customer_data = CustomerFactory().serialize()
         test_customer_data["active"] = False
 


### PR DESCRIPTION
1. Regenerated Codecov token and added token to ci.yml.
2. Code coverage Report is being generated now for every PR.

Our badge kept showing the old coverage: 97